### PR TITLE
Adição de funcionalidades para negar e cancelar compromissos.

### DIFF
--- a/src/main/java/com/dra/frontend/controller/CompromissoController.java
+++ b/src/main/java/com/dra/frontend/controller/CompromissoController.java
@@ -2,11 +2,15 @@ package com.dra.frontend.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
+import com.dra.frontend.model.Compromisso;
 import com.dra.frontend.service.CompromissoService;
 
 
@@ -17,17 +21,16 @@ public class CompromissoController {
 
     @Autowired
     CompromissoService compromissoService;
-	
-    @PostMapping("/negar")
-    public String negarCompromisso(@RequestParam("id") long id) {
-        compromissoService.negarCompromisso(id);
-        return "redirect:/compromisso";
+    
+    @PostMapping("/{id}")
+    public String negarContato(@PathVariable long id, @Validated Compromisso compromisso, BindingResult result, Model model) {
+    	 compromissoService.postCompromisso(compromisso);
+    	return "redirect:/compromisso";
     }
-
-    @PutMapping("/cancelar")
-    public String cancelarCompromisso(@RequestParam("id") long id) {
-        compromissoService.cancelarCompromisso(id);
-        return "redirect:/compromisso";
+    
+    @PutMapping("/{id}")
+    public String cancelarContato(@PathVariable long id, @Validated Compromisso compromisso, BindingResult result, Model model) {
+    	 compromissoService.putCompromisso(id, compromisso);
+    	return "redirect:/compromisso";
     }
-	
 }

--- a/src/main/java/com/dra/frontend/controller/CompromissoController.java
+++ b/src/main/java/com/dra/frontend/controller/CompromissoController.java
@@ -23,13 +23,13 @@ public class CompromissoController {
     CompromissoService compromissoService;
     
     @PostMapping("/{id}")
-    public String negarContato(@PathVariable long id, @Validated Compromisso compromisso, BindingResult result, Model model) {
+    public String negarCompromisso(@PathVariable long id, @Validated Compromisso compromisso, BindingResult result, Model model) {
     	 compromissoService.postCompromisso(compromisso);
     	return "redirect:/compromisso";
     }
     
     @PutMapping("/{id}")
-    public String cancelarContato(@PathVariable long id, @Validated Compromisso compromisso, BindingResult result, Model model) {
+    public String cancelarCompromisso(@PathVariable long id, @Validated Compromisso compromisso, BindingResult result, Model model) {
     	 compromissoService.putCompromisso(id, compromisso);
     	return "redirect:/compromisso";
     }

--- a/src/main/java/com/dra/frontend/controller/CompromissoController.java
+++ b/src/main/java/com/dra/frontend/controller/CompromissoController.java
@@ -2,7 +2,10 @@ package com.dra.frontend.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.dra.frontend.service.CompromissoService;
 
@@ -14,5 +17,17 @@ public class CompromissoController {
 
     @Autowired
     CompromissoService compromissoService;
-    
+	
+    @PostMapping("/negar")
+    public String negarCompromisso(@RequestParam("id") long id) {
+        compromissoService.negarCompromisso(id);
+        return "redirect:/compromisso";
+    }
+
+    @PutMapping("/cancelar")
+    public String cancelarCompromisso(@RequestParam("id") long id) {
+        compromissoService.cancelarCompromisso(id);
+        return "redirect:/compromisso";
+    }
+	
 }

--- a/src/main/java/com/dra/frontend/model/Compromisso.java
+++ b/src/main/java/com/dra/frontend/model/Compromisso.java
@@ -1,5 +1,6 @@
 package com.dra.frontend.model;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,54 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Compromisso {
+	
+    private Long id;
+    @NotBlank
     private String nome;
+    @NotBlank
+    private String status;
+    @NotBlank
+    private String local;
+    @NotBlank
+    private String descricao;
+    
+	public Long getId() {
+		return id;
+	}
+	public void setId(Long id) {
+		this.id = id;
+	}
+	public String getNome() {
+		return nome;
+	}
+	public void setNome(String nome) {
+		this.nome = nome;
+	}
+	public String getStatus() {
+		return status;
+	}
+	public void setStatus(String status) {
+		this.status = status;
+	}
+	public String getLocal() {
+		return local;
+	}
+	public void setLocal(String local) {
+		this.local = local;
+	}
+	public String getDescricao() {
+		return descricao;
+	}
+	public void setDescricao(String descricao) {
+		this.descricao = descricao;
+	}
+   
+    public void negar() {
+        this.status = "NEGADO";
+    }
 
+    public void cancelar() {
+        this.status = "CANCELADO";
+    }
     
 }

--- a/src/main/java/com/dra/frontend/service/CompromissoService.java
+++ b/src/main/java/com/dra/frontend/service/CompromissoService.java
@@ -1,8 +1,22 @@
 package com.dra.frontend.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 public class CompromissoService {
-    
+	
+	private final String url = "http://localhost:8080/compromisso"; 
+	
+    public void negarCompromisso(long id) {
+        RestTemplate restTemplate = new RestTemplate();
+        String urlNegar = url + "/negar/" + Long.toString(id);
+        restTemplate.postForObject(urlNegar, null, Void.class);
+    }
+
+    public void cancelarCompromisso(long id) {
+        RestTemplate restTemplate = new RestTemplate();
+        String urlCancelar = url + "/cancelar/" + Long.toString(id);
+        restTemplate.put(urlCancelar, null);
+    }
 }

--- a/src/main/java/com/dra/frontend/service/CompromissoService.java
+++ b/src/main/java/com/dra/frontend/service/CompromissoService.java
@@ -1,22 +1,49 @@
 package com.dra.frontend.service;
 
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import com.dra.frontend.model.Compromisso;
 
 @Service
 public class CompromissoService {
 	
 	private final String url = "http://localhost:8080/compromisso"; 
 	
-    public void negarCompromisso(long id) {
-        RestTemplate restTemplate = new RestTemplate();
-        String urlNegar = url + "/negar/" + Long.toString(id);
-        restTemplate.postForObject(urlNegar, null, Void.class);
-    }
-
-    public void cancelarCompromisso(long id) {
-        RestTemplate restTemplate = new RestTemplate();
-        String urlCancelar = url + "/cancelar/" + Long.toString(id);
-        restTemplate.put(urlCancelar, null);
-    }
+public Compromisso postCompromisso(Compromisso compromisso) {
+		
+		RestTemplate restTemplate = new RestTemplate();
+		
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		
+		HttpEntity<Compromisso> requestBody = new HttpEntity<>(compromisso, headers);
+		
+		ResponseEntity<Compromisso> response = restTemplate.postForEntity(
+				url,
+				requestBody, Compromisso.class);
+		
+		return response.getBody();
+	}
+	
+	public Compromisso putCompromisso(long id, Compromisso compromisso) {
+		RestTemplate restTemplate = new RestTemplate();
+		
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		
+		HttpEntity<Compromisso> requestBody = new HttpEntity<>(compromisso, headers);
+		
+		String urlPut = url + "/" + Long.toString(id);
+		ResponseEntity<Compromisso> response = restTemplate.exchange(urlPut, HttpMethod.PUT,requestBody, Compromisso.class);
+		return response.getBody();
+		
+	}
 }


### PR DESCRIPTION
**#CompromissoService:**

- Adicionado método negarCompromisso(long id) para enviar uma solicitação POST ao endpoint "/compromisso/negar/{id}" e negar um compromisso.
- Adicionado método cancelarCompromisso(long id) para enviar uma solicitação PUT ao endpoint "/compromisso/cancelar/{id}" e cancelar um compromisso.

**#CompromissoController:**

- Criado endpoint @PostMapping("/negar") para acionar o método negarCompromisso do serviço, permitindo a negação de compromissos.
- Criado endpoint @PutMapping("/cancelar") para acionar o método cancelarCompromisso do serviço, permitindo o cancelamento de compromissos.

**#Compromisso:**

- Adicionados métodos negar() e cancelar() à classe Compromisso para encapsular as ações de negar e cancelar um compromisso.
**Coloquei esses metodos na claasse de compromisso para possibilitar interações mais eficientes entre o front-end e o back-end para implementar as funcionalidades de negar e cancelar compromissos.